### PR TITLE
adds docker file and documentation for ApacheAnt

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ There still a few more things it can be done:
 - tomcat 5.5 and above
 
 ## Build and Installation
+
+### Apache ANT
 Under the ./java directory there is a `build.xml` *ant* file.
 
 To list available *ant* commands/targets do:
@@ -138,6 +140,18 @@ Default target: dist
 
 by running `ant` or `ant dist` a `vospace-2.0.war` will be created. Then simply copy/drop
 that file into your tomcat webapps directory and restart tomcat server.
+
+#### ANT with Docker
+There is a Docker file available for those that do not have a local Java environment. To run Apache Ant with docker first build the image and then run the desired the commands.
+1. If you do not have a local image for ANT first build it
+```
+docker build -f ./docker/ApacheAnt/Dockerfile -t apache-ant .
+```
+2. Now run various ANT commands using the image above:
+```
+docker run --hostname vostest -v ./java:/app apache-ant [command]
+```
+**Note:** hostname should match the appropriate properties file. Options are ```vostest, gp04, dltest, dldev, dldb1```
 
 ## Testing
 

--- a/docker/ApacheAnt/Dockerfile
+++ b/docker/ApacheAnt/Dockerfile
@@ -1,0 +1,24 @@
+FROM amazoncorretto:8-alpine
+
+# setup our working directory
+RUN mkdir -p /app
+WORKDIR /app
+
+# ensure git is available since our apps sometimes use git commands
+RUN apk add git
+
+# set specific ANT versions
+ENV ANT_VERSION=1.10.14
+ENV ANT_HOME=/opt/ant
+
+# Download and extract apache ant to opt folder
+RUN wget --no-check-certificate http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && wget --no-check-certificate http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz.sha512 \
+    && echo "$(cat apache-ant-${ANT_VERSION}-bin.tar.gz.sha512) apache-ant-${ANT_VERSION}-bin.tar.gz" | sha512sum -c \
+    && tar -zvxf apache-ant-${ANT_VERSION}-bin.tar.gz -C /opt/ \
+    && ln -s /opt/apache-ant-${ANT_VERSION} /opt/ant \
+    && rm -f apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && rm -f apache-ant-${ANT_VERSION}-bin.tar.gz.sha512
+
+# set entry to ant with a default command of "dist"
+ENTRYPOINT [ "/opt/ant/bin/ant" ]


### PR DESCRIPTION
This adds a new Docker file which can be used in instances where a compatible Java environment isn't present. This also includes the necessary documentation on how to use the Dockerfile and image.